### PR TITLE
fix for TC_BLOCKDATA size in unsigned byte type

### DIFF
--- a/src/nb/deser/SerializationDumper.java
+++ b/src/nb/deser/SerializationDumper.java
@@ -1017,7 +1017,7 @@ public class SerializationDumper {
 		this.increaseIndent();
 		
 		//size
-		len = (int)this._data.pop();
+		len = this._data.pop() & 0xFF;
 		this.print("Length - " + len + " - 0x" + this.byteToHex((byte)(len & 0xff)));
 		
 		//contents


### PR DESCRIPTION
If `size` in TC_BLOCKDATA is greater than 127 it will crash, because of the improper type conversion which makes `len` negative.